### PR TITLE
Update utils.js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -287,7 +287,7 @@ ko.utils = (function () {
             // IE6 sometimes throws "unknown error" if you try to write to .selected directly, whereas Firefox struggles with setAttribute. Pick one based on browser.
             if (ieVersion < 7)
                 optionNode.setAttribute("selected", isSelected);
-            else
+            else if (optionNode.selected != isSelected)
                 optionNode.selected = isSelected;
         },
 


### PR DESCRIPTION
Update to not re-select or re-deselect option elements that are already in the desired state.  Fixes IE issue outlined here:
http://stackoverflow.com/questions/28683205/knockoutjs-multiselect-issue-in-internet-explorer
